### PR TITLE
SB-469: Add 1.5.10 runtime version and associated boosters.

### DIFF
--- a/circuit-breaker/spring-boot/1.5.10-community/booster.yaml
+++ b/circuit-breaker/spring-boot/1.5.10-community/booster.yaml
@@ -1,0 +1,6 @@
+source:
+  git:
+    ref: sb-1.5.10
+metadata:
+  version:
+    name: 1.5.10.RELEASE (Community Beta)

--- a/circuit-breaker/spring-boot/1.5.8-community/booster.yaml
+++ b/circuit-breaker/spring-boot/1.5.8-community/booster.yaml
@@ -1,6 +1,5 @@
 source:
   git:
-    url: https://github.com/snowdrop/spring-boot-http-booster
     ref: master
 metadata:
   version:
@@ -9,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v13
+        ref: v11
   production:
     source:
       git:
-        ref: v13
+        ref: v11

--- a/circuit-breaker/spring-boot/1.5.8-redhat/booster.yaml
+++ b/circuit-breaker/spring-boot/1.5.8-redhat/booster.yaml
@@ -1,6 +1,5 @@
 source:
   git:
-    url: https://github.com/snowdrop/spring-boot-http-booster
     ref: redhat
 metadata:
   version:

--- a/circuit-breaker/spring-boot/common.yaml
+++ b/circuit-breaker/spring-boot/common.yaml
@@ -1,2 +1,5 @@
 name: Spring Boot Circuit Breaker Example
 description: Quickstart to demonstrate Circuit Breaker pattern with Spring Boot.
+source:
+  git:
+    url: https://github.com/snowdrop/spring-boot-circuit-breaker-booster

--- a/configmap/spring-boot/1.5.10-community/booster.yaml
+++ b/configmap/spring-boot/1.5.10-community/booster.yaml
@@ -1,0 +1,6 @@
+source:
+  git:
+    ref: sb-1.5.10
+metadata:
+  version:
+    name: 1.5.10.RELEASE (Community Beta)

--- a/configmap/spring-boot/1.5.8-community/booster.yaml
+++ b/configmap/spring-boot/1.5.8-community/booster.yaml
@@ -1,6 +1,5 @@
 source:
   git:
-    url: https://github.com/snowdrop/spring-boot-configmap-booster
     ref: master
 metadata:
   version:

--- a/configmap/spring-boot/1.5.8-redhat/booster.yaml
+++ b/configmap/spring-boot/1.5.8-redhat/booster.yaml
@@ -1,6 +1,5 @@
 source:
   git:
-    url: https://github.com/snowdrop/spring-boot-health-check-booster
     ref: redhat
 metadata:
   version:

--- a/configmap/spring-boot/common.yaml
+++ b/configmap/spring-boot/common.yaml
@@ -1,2 +1,5 @@
 name: Spring Boot - ConfigMap Example
 description: Booster to expose an HTTP Greeting endpoint using Spring Boot where the message is defined as a Kubernetes ConfigMap property
+source:
+  git:
+    url: https://github.com/snowdrop/spring-boot-configmap-booster

--- a/crud/spring-boot/1.5.10-community/booster.yaml
+++ b/crud/spring-boot/1.5.10-community/booster.yaml
@@ -1,0 +1,6 @@
+source:
+  git:
+    ref: sb-1.5.10
+metadata:
+  version:
+    name: 1.5.10.RELEASE (Community Beta)

--- a/crud/spring-boot/1.5.8-community/booster.yaml
+++ b/crud/spring-boot/1.5.8-community/booster.yaml
@@ -1,6 +1,5 @@
 source:
   git:
-    url: https://github.com/snowdrop/spring-boot-health-check-booster
     ref: master
 metadata:
   version:
@@ -9,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v12
+        ref: v15
   production:
     source:
       git:
-        ref: v12
+        ref: v15

--- a/crud/spring-boot/1.5.8-redhat/booster.yaml
+++ b/crud/spring-boot/1.5.8-redhat/booster.yaml
@@ -1,6 +1,5 @@
 source:
   git:
-    url: https://github.com/snowdrop/spring-boot-crud-booster
     ref: redhat
 metadata:
   version:

--- a/crud/spring-boot/common.yaml
+++ b/crud/spring-boot/common.yaml
@@ -1,2 +1,5 @@
 name: Spring Boot - CRUD Example
 description: Booster to expose an HTTP endpoint with CRUD operations on fruits database.
+source:
+  git:
+    url: https://github.com/snowdrop/spring-boot-crud-booster

--- a/health-check/spring-boot/1.5.10-community/booster.yaml
+++ b/health-check/spring-boot/1.5.10-community/booster.yaml
@@ -1,0 +1,6 @@
+source:
+  git:
+    ref: 1.5.10
+metadata:
+  version:
+    name: 1.5.10.RELEASE (Community Beta)

--- a/health-check/spring-boot/1.5.8-community/booster.yaml
+++ b/health-check/spring-boot/1.5.8-community/booster.yaml
@@ -1,6 +1,5 @@
 source:
   git:
-    url: https://github.com/snowdrop/spring-boot-circuit-breaker-booster
     ref: master
 metadata:
   version:
@@ -9,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v11
+        ref: v12
   production:
     source:
       git:
-        ref: v11
+        ref: v12

--- a/health-check/spring-boot/1.5.8-redhat/booster.yaml
+++ b/health-check/spring-boot/1.5.8-redhat/booster.yaml
@@ -1,6 +1,5 @@
 source:
   git:
-    url: https://github.com/snowdrop/spring-boot-configmap-booster
     ref: redhat
 metadata:
   version:

--- a/health-check/spring-boot/common.yaml
+++ b/health-check/spring-boot/common.yaml
@@ -1,2 +1,5 @@
 name: Spring Boot Health Check Example
 description: Quickstart to demonstrate OpenShift health probes working with Spring Boot Actuator
+source:
+  git:
+    url: https://github.com/snowdrop/spring-boot-health-check-booster

--- a/rest-http-secured/spring-boot/1.5.10-community/booster.yaml
+++ b/rest-http-secured/spring-boot/1.5.10-community/booster.yaml
@@ -1,0 +1,6 @@
+source:
+  git:
+    ref: sb-1.5.10
+metadata:
+  version:
+    name: 1.5.10.RELEASE (Community Beta)

--- a/rest-http-secured/spring-boot/1.5.8-community/booster.yaml
+++ b/rest-http-secured/spring-boot/1.5.8-community/booster.yaml
@@ -1,6 +1,5 @@
 source:
   git:
-    url: https://github.com/snowdrop/spring-boot-http-secured-booster
     ref: master
 metadata:
   version:

--- a/rest-http-secured/spring-boot/1.5.8-redhat/booster.yaml
+++ b/rest-http-secured/spring-boot/1.5.8-redhat/booster.yaml
@@ -1,6 +1,5 @@
 source:
   git:
-    url: https://github.com/snowdrop/spring-boot-http-secured-booster
     ref: master
 metadata:
   version:

--- a/rest-http-secured/spring-boot/common.yaml
+++ b/rest-http-secured/spring-boot/common.yaml
@@ -1,2 +1,5 @@
 name: Secured Spring Boot - HTTP & Red Hat SSO Example
 description: Application to expose a HTTP Greeting endpoint using SpringBoot & Secured by Red Hat SSO
+source:
+  git:
+    url: https://github.com/snowdrop/spring-boot-http-secured-booster

--- a/rest-http/spring-boot/1.5.10-community/booster.yaml
+++ b/rest-http/spring-boot/1.5.10-community/booster.yaml
@@ -1,0 +1,6 @@
+source:
+  git:
+    ref: sb-1.5.10
+metadata:
+  version:
+    name: 1.5.10.RELEASE (Community Beta)

--- a/rest-http/spring-boot/1.5.8-community/booster.yaml
+++ b/rest-http/spring-boot/1.5.8-community/booster.yaml
@@ -1,6 +1,5 @@
 source:
   git:
-    url: https://github.com/snowdrop/spring-boot-crud-booster
     ref: master
 metadata:
   version:
@@ -9,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v15
+        ref: v13
   production:
     source:
       git:
-        ref: v15
+        ref: v13

--- a/rest-http/spring-boot/1.5.8-redhat/booster.yaml
+++ b/rest-http/spring-boot/1.5.8-redhat/booster.yaml
@@ -1,6 +1,5 @@
 source:
   git:
-    url: https://github.com/snowdrop/spring-boot-circuit-breaker-booster
     ref: redhat
 metadata:
   version:

--- a/rest-http/spring-boot/common.yaml
+++ b/rest-http/spring-boot/common.yaml
@@ -1,2 +1,5 @@
 name: Spring Boot - HTTP Example
 description: Quickstart to expose a HTTP Greeting endpoint using Spring Boot and Apache Tomcat in embedded mode
+source:
+  git:
+    url: https://github.com/snowdrop/spring-boot-http-booster


### PR DESCRIPTION
- New runtime version is named 1.5.10-community
- Renamed previous runtimes:
    + community -> 1.5.8-community
    + redhat -> 1.5.8-redhat
- Moved source.git.url definition for all boosters to common.yaml.