### PR TITLE
Update the Vert.x HTTP booster version

### DIFF
--- a/vert.x/community/rest-http/booster.yaml
+++ b/vert.x/community/rest-http/booster.yaml
@@ -10,11 +10,11 @@ environment:
   staging:
     source:
       git:
-        ref: v22
+        ref: v23
   production:
     source:
       git:
-        ref: v22
+        ref: v23
     metadata:
       version:
         name: 3.5.0.Final (Community)


### PR DESCRIPTION
After having fixed the hardcoded FMP version