### PR TITLE
Update Vert.x booster versions

### DIFF
--- a/vert.x/community/circuit-breaker/booster.yaml
+++ b/vert.x/community/circuit-breaker/booster.yaml
@@ -10,11 +10,11 @@ environment:
   staging:
     source:
       git:
-        ref: v15
+        ref: v16
   production:
     source:
       git:
-        ref: v15
+        ref: v16
     metadata:
       version:
         name: 3.5.0.Final (Community)

--- a/vert.x/community/configmap/booster.yaml
+++ b/vert.x/community/configmap/booster.yaml
@@ -10,11 +10,11 @@ environment:
   staging:
     source:
       git:
-        ref: v24
+        ref: v25
   production:
     source:
       git:
-        ref: v24
+        ref: v25
     metadata:
       version:
         name: 3.5.0.Final (Community)

--- a/vert.x/community/crud/booster.yaml
+++ b/vert.x/community/crud/booster.yaml
@@ -10,11 +10,11 @@ environment:
   staging:
     source:
       git:
-        ref: v23
+        ref: v24
   production:
     source:
       git:
-        ref: v23
+        ref: v24
     metadata:
       version:
         name: 3.5.0.Final (Community)

--- a/vert.x/community/health-check/booster.yaml
+++ b/vert.x/community/health-check/booster.yaml
@@ -10,11 +10,11 @@ environment:
   staging:
     source:
       git:
-        ref: v19
+        ref: v20
   production:
     source:
       git:
-        ref: v19
+        ref: v20
     metadata:
       version:
         name: 3.5.0.Final (Community)

--- a/vert.x/community/rest-http/booster.yaml
+++ b/vert.x/community/rest-http/booster.yaml
@@ -10,11 +10,11 @@ environment:
   staging:
     source:
       git:
-        ref: v24
+        ref: v25
   production:
     source:
       git:
-        ref: v24
+        ref: v25
     metadata:
       version:
         name: 3.5.0.Final (Community)

--- a/vert.x/redhat/circuit-breaker/booster.yaml
+++ b/vert.x/redhat/circuit-breaker/booster.yaml
@@ -10,8 +10,8 @@ environment:
   staging:
     source:
       git:
-        ref: v9
+        ref: v10
   production:
     source:
       git:
-        ref: v9
+        ref: v10

--- a/vert.x/redhat/configmap/booster.yaml
+++ b/vert.x/redhat/configmap/booster.yaml
@@ -10,8 +10,8 @@ environment:
   staging:
     source:
       git:
-        ref: v10
+        ref: v11
   production:
     source:
       git:
-        ref: v10
+        ref: v11

--- a/vert.x/redhat/crud/booster.yaml
+++ b/vert.x/redhat/crud/booster.yaml
@@ -10,8 +10,8 @@ environment:
   staging:
     source:
       git:
-        ref: v9
+        ref: v10
   production:
     source:
       git:
-        ref: v9
+        ref: v10

--- a/vert.x/redhat/health-check/booster.yaml
+++ b/vert.x/redhat/health-check/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v10
+        ref: v11
   production:
     source:
       git:
-        ref: v10
+        ref: v11

--- a/vert.x/redhat/rest-http-secured/booster.yaml
+++ b/vert.x/redhat/rest-http-secured/booster.yaml
@@ -2,7 +2,7 @@ metadata:
   runsOn: none
 source:
   git:
-    url: https://github.com/openshiftio-vertx-boosters/vertx-secured-http-booster
+    url: https://github.com/openshiftio-vertx-boosters/vertx-secured-http-booster-redhat
     ref: master
 name: Secured Vertx - Rest & Red Hat SSO
 description: Quickstart to expose a REST Greeting endpoint using Eclipse Vert.x & Secured by Red Hat SSO
@@ -10,11 +10,8 @@ environment:
   staging:
     source:
       git:
-        ref: v18
+        ref: v17
   production:
     source:
       git:
-        ref: v18
-    metadata:
-      version:
-        name: 3.5.0.Final (Community)
+        ref: v17

--- a/vert.x/redhat/rest-http/booster.yaml
+++ b/vert.x/redhat/rest-http/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v10
+        ref: v11
   production:
     source:
       git:
-        ref: v10
+        ref: v11


### PR DESCRIPTION
This update should fix the `image:' '` issue from the FMP (https://github.com/fabric8io/fabric8-maven-plugin/issues/1237). The `application.yaml` are now generated without the `fabric8.openshift.trimImageInContainerSpec` option.

This update also declare the Redhat SSO booster using redhat bits.

Finally, the boosters have been their licenses file (licenses.xml, licenses.html) updated.