### PR TITLE
Disable springboot-configmap, wildfly-swarm-configmap and wildfly-swarm-health-check booster

### DIFF
--- a/spring-boot/current-osio/configmap/booster.yaml
+++ b/spring-boot/current-osio/configmap/booster.yaml
@@ -1,5 +1,5 @@
 metadata:
-  runsOn: 'osio'
+  runsOn: '!osio'
 name: Spring Boot - ConfigMap Example
 description: Booster to expose an HTTP Greeting endpoint using Spring Boot where the message is defined as a Kubernetes ConfigMap property.
 source:

--- a/wildfly-swarm/redhat/configmap/booster.yaml
+++ b/wildfly-swarm/redhat/configmap/booster.yaml
@@ -1,3 +1,6 @@
+metadata:
+  runsOn: 
+    - '!osio'
 name: WildFly Swarm - Config Map
 description: Simple HTTP endpoint where the WildFly Swarm application uses OpenShift ConfigMap to retrieve application parameters.
 source:

--- a/wildfly-swarm/redhat/health-check/booster.yaml
+++ b/wildfly-swarm/redhat/health-check/booster.yaml
@@ -1,3 +1,6 @@
+metadata:
+  runsOn: 
+    - '!osio'
 name: WildFly Swarm - Health Checks
 description: Demonstrates Health Checks in Wildfly Swarm
 source:


### PR DESCRIPTION
Build for springboot-configmap, wildfly-swarm-configmap and wildfly-swarm-health-check boosters are failing so disabling that.

Logs:
Springboot-configmap: https://github.com/openshiftio/openshift.io/issues//3131
Wildfly-Swarm-configmap: https://github.com/openshiftio/openshift.io/issues//3134
Wildfly-Swarm-health-check: https://github.com/openshiftio/openshift.io/issues//3124