### PR TITLE
Disabling wildfly-swarm rest-http booster

### DIFF
--- a/wildfly-swarm/redhat/rest-http/booster.yaml
+++ b/wildfly-swarm/redhat/rest-http/booster.yaml
@@ -1,3 +1,6 @@
+metadata:
+  runsOn: 
+    - '!osio'
 name: WildFly Swarm - HTTP
 description: Runs a WildFly Swarm HTTP application
 source:


### PR DESCRIPTION
wildflyswarm rest-http booster build is failing so disabling this.

Related Issue: https://github.com/openshiftio/openshift.io/issues/3430