### PR TITLE
update booster version to 14

### DIFF
--- a/vert.x/redhat/configmap/booster.yaml
+++ b/vert.x/redhat/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v13
+        ref: v14
   production:
     source:
       git:
-        ref: v13
+        ref: v14


### PR DESCRIPTION
This PR updates the vert.x config map booster (-redhat) version to enable local development in Che.

It's related to:
* https://github.com/openshiftio-vertx-boosters/vertx-configmap-booster-redhat/issues/14
* https://github.com/openshiftio/openshift.io/issues/2988#issuecomment-386788483