### PR TITLE
fix(descriptor): remove empty metadata

### DIFF
--- a/spring-boot/current-redhat/health-check/booster.yaml
+++ b/spring-boot/current-redhat/health-check/booster.yaml
@@ -4,4 +4,3 @@ source:
   git:
     url: https://github.com/snowdrop/spring-boot-health-check-booster
     ref: 1.5.12-2-redhat
-metadata:

--- a/spring-boot/current-redhat/rest-http/booster.yaml
+++ b/spring-boot/current-redhat/rest-http/booster.yaml
@@ -4,4 +4,3 @@ source:
   git:
     url: https://github.com/snowdrop/spring-boot-http-booster
     ref: 1.5.12-2-redhat
-metadata:


### PR DESCRIPTION
An empty metadata tag causes the following exception:

```
Caused by: java.lang.NullPointerException
  | at java.util.Collections$UnmodifiableMap.<init>(Collections.java:1446)
  | at java.util.Collections.unmodifiableMap(Collections.java:1433)
  | at io.fabric8.launcher.booster.catalog.Booster.getMetadata(Booster.java:260)
  | at io.fabric8.launcher.web.endpoints.BoosterCatalogEndpoint.lambda$getRuntimes$0(BoosterCatalogEndpoint.java:110)
  | at java.util.Optional.ifPresent(Optional.java:159)
  | at io.fabric8.launcher.web.endpoints.BoosterCatalogEndpoint.getRuntimes(BoosterCatalogEndpoint.java:108)
  | at io.fabric8.launcher.web.endpoints.BoosterCatalogEndpoint$Proxy$_$$_WeldSubclass.getRuntimes(Unknown Source)
  | at io.fabric8.launcher.web.endpoints.BoosterCatalogEndpoint$Proxy$_$$_WeldClientProxy.getRuntimes(Unknown Source)
 

```