### PR TITLE
fix(fuse): fixed fuse boosters

### DIFF
--- a/fuse/2.21.0-community/health-check/booster.yaml
+++ b/fuse/2.21.0-community/health-check/booster.yaml
@@ -1,5 +1,5 @@
 metadata:
-￼  runsOn: '!osio'
+  runsOn: '!osio'
 name: Red Hat Fuse - Health Check Example
 description: Booster to demonstrate OpenShift health probes working with Apache Camel through Spring Boot Actuator.
 source:

--- a/fuse/2.21.0-community/rest-http/booster.yaml
+++ b/fuse/2.21.0-community/rest-http/booster.yaml
@@ -1,5 +1,5 @@
 metadata:
-￼  runsOn: '!osio'
+  runsOn: '!osio'
 name: Red Hat Fuse - HTTP Example
 description: Booster to expose a HTTP Greeting endpoint using Apache camel, Spring Boot and Undertow.
 source:

--- a/fuse/7.0.0-redhat/health-check/booster.yaml
+++ b/fuse/7.0.0-redhat/health-check/booster.yaml
@@ -1,5 +1,5 @@
 metadata:
-￼  runsOn: '!osio'
+  runsOn: '!osio'
 name: Red Hat Fuse - Health Check Example
 description: Booster to demonstrate OpenShift health probes working with Apache Camel through Spring Boot Actuator.
 source:

--- a/fuse/7.0.0-redhat/rest-http/booster.yaml
+++ b/fuse/7.0.0-redhat/rest-http/booster.yaml
@@ -1,5 +1,5 @@
 metadata:
-￼  runsOn: '!osio'
+  runsOn: '!osio'
 name: Red Hat Fuse - HTTP Example
 description: Booster to expose a HTTP REST endpoint using Apache camel, Spring Boot and Undertow.
 source:


### PR DESCRIPTION
Some booster.yaml files had extra invisible characters throwing off the parser