### PR TITLE
Vert.x 3.5.1.redhat-004 updates

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -67,7 +67,7 @@ runtimes:
     pipelinePlatform: maven
   versions:
   - id: redhat
-    name: 3.5.1.redhat-003 (RHOAR)
+    name: 3.5.1.redhat-004 (RHOAR)
   - id: community
     name: 3.5.0.Final (Community)
 - id: fuse

--- a/vert.x/redhat/cache/booster.yaml
+++ b/vert.x/redhat/cache/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v1
+        ref: v2
   production:
     source:
       git:
-        ref: v1
+        ref: v2

--- a/vert.x/redhat/circuit-breaker/booster.yaml
+++ b/vert.x/redhat/circuit-breaker/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v11
+        ref: v12
   production:
     source:
       git:
-        ref: v11
+        ref: v12

--- a/vert.x/redhat/configmap/booster.yaml
+++ b/vert.x/redhat/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v14
+        ref: v15
   production:
     source:
       git:
-        ref: v14
+        ref: v15

--- a/vert.x/redhat/crud/booster.yaml
+++ b/vert.x/redhat/crud/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v11
+        ref: v12
   production:
     source:
       git:
-        ref: v11
+        ref: v12

--- a/vert.x/redhat/health-check/booster.yaml
+++ b/vert.x/redhat/health-check/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v12
+        ref: v13
   production:
     source:
       git:
-        ref: v12
+        ref: v13

--- a/vert.x/redhat/rest-http-secured/booster.yaml
+++ b/vert.x/redhat/rest-http-secured/booster.yaml
@@ -14,8 +14,8 @@ environment:
   staging:
     source:
       git:
-        ref: v18
+        ref: v19
   production:
     source:
       git:
-        ref: v18
+        ref: v19

--- a/vert.x/redhat/rest-http/booster.yaml
+++ b/vert.x/redhat/rest-http/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v12
+        ref: v13
   production:
     source:
       git:
-        ref: v12
+        ref: v13


### PR DESCRIPTION
* Update the Vert.x version in the metadata.yaml
* Update the Vert.x booster versions

This commit only changes the boosters using productized modules.