### PR TITLE
Update Vert.x boosters - booster parent 23, Vert.x Community 3.5.2

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -69,7 +69,7 @@ runtimes:
   - id: redhat
     name: 3.5.1.redhat-004 (RHOAR)
   - id: community
-    name: 3.5.0.Final (Community)
+    name: 3.5.2.Final (Community)
 - id: fuse
   name: Fuse
   description: The Fuse runtime enables you to deploy Spring Boot applications on OpenShift while leveraging the Fuse technology stack for middleware integration. The core technology provided by Fuse is Apache Camel for application integration including Spring Boot starters for the Camel components. The technology stack also provides transactions, Web services, security, management, and messaging clients.

--- a/vert.x/community/cache/booster.yaml
+++ b/vert.x/community/cache/booster.yaml
@@ -11,8 +11,8 @@ environment:
   staging:
     source:
       git:
-        ref: v1
+        ref: v2
   production:
     source:
       git:
-        ref: v1
+        ref: v2

--- a/vert.x/community/circuit-breaker/booster.yaml
+++ b/vert.x/community/circuit-breaker/booster.yaml
@@ -13,11 +13,8 @@ environment:
   staging:
     source:
       git:
-        ref: v16
+        ref: v17
   production:
     source:
       git:
-        ref: v16
-    metadata:
-      version:
-        name: 3.5.0.Final (Community)
+        ref: v17    

--- a/vert.x/community/configmap/booster.yaml
+++ b/vert.x/community/configmap/booster.yaml
@@ -8,11 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v26
+        ref: v27
   production:
     source:
       git:
-        ref: v26
-    metadata:
-      version:
-        name: 3.5.0.Final (Community)
+        ref: v27

--- a/vert.x/community/crud/booster.yaml
+++ b/vert.x/community/crud/booster.yaml
@@ -13,11 +13,8 @@ environment:
   staging:
     source:
       git:
-        ref: v24
+        ref: v25
   production:
     source:
       git:
-        ref: v24
-    metadata:
-      version:
-        name: 3.5.0.Final (Community)
+        ref: v25

--- a/vert.x/community/health-check/booster.yaml
+++ b/vert.x/community/health-check/booster.yaml
@@ -8,11 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v20
+        ref: v21
   production:
     source:
       git:
-        ref: v20
-    metadata:
-      version:
-        name: 3.5.0.Final (Community)
+        ref: v21

--- a/vert.x/community/rest-http-secured/booster.yaml
+++ b/vert.x/community/rest-http-secured/booster.yaml
@@ -12,11 +12,8 @@ environment:
   staging:
     source:
       git:
-        ref: v18
+        ref: v19
   production:
     source:
       git:
-        ref: v18
-    metadata:
-      version:
-        name: 3.5.0.Final (Community)
+        ref: v19

--- a/vert.x/community/rest-http/booster.yaml
+++ b/vert.x/community/rest-http/booster.yaml
@@ -8,11 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v25
+        ref: v26
   production:
     source:
       git:
-        ref: v25
-    metadata:
-      version:
-        name: 3.5.0.Final (Community)
+        ref: v26

--- a/vert.x/redhat/cache/booster.yaml
+++ b/vert.x/redhat/cache/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v2
+        ref: v3
   production:
     source:
       git:
-        ref: v2
+        ref: v3

--- a/vert.x/redhat/circuit-breaker/booster.yaml
+++ b/vert.x/redhat/circuit-breaker/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v12
+        ref: v13
   production:
     source:
       git:
-        ref: v12
+        ref: v13

--- a/vert.x/redhat/configmap/booster.yaml
+++ b/vert.x/redhat/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v15
+        ref: v16
   production:
     source:
       git:
-        ref: v15
+        ref: v16

--- a/vert.x/redhat/crud/booster.yaml
+++ b/vert.x/redhat/crud/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v12
+        ref: v13
   production:
     source:
       git:
-        ref: v12
+        ref: v13

--- a/vert.x/redhat/health-check/booster.yaml
+++ b/vert.x/redhat/health-check/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v13
+        ref: v14
   production:
     source:
       git:
-        ref: v13
+        ref: v14

--- a/vert.x/redhat/rest-http-secured/booster.yaml
+++ b/vert.x/redhat/rest-http-secured/booster.yaml
@@ -14,8 +14,8 @@ environment:
   staging:
     source:
       git:
-        ref: v19
+        ref: v20
   production:
     source:
       git:
-        ref: v19
+        ref: v20

--- a/vert.x/redhat/rest-http/booster.yaml
+++ b/vert.x/redhat/rest-http/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v13
+        ref: v14
   production:
     source:
       git:
-        ref: v13
+        ref: v14


### PR DESCRIPTION
These new versions are using:
* Vert.x Red Hat: 3.5.1.redhat-004
* Vert.x Community: 3.5.2 (updated)
* FMP Version: 3.5.40 (updated)
* VMP Version: 1.0.15
* booster-parent version: 23 (updated)

This release is related to https://github.com/openshiftio/booster-parent/issues/29.

Community boosters have been updated to Vert.x 3.5.2.
