### PR TITLE
chore: update node.js boosters

### DIFF
--- a/nodejs/v10-community/istio-circuit-breaker/booster.yaml
+++ b/nodejs/v10-community/istio-circuit-breaker/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v10-community/istio-distributed-tracing/booster.yaml
+++ b/nodejs/v10-community/istio-distributed-tracing/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v10-community/istio-routing/booster.yaml
+++ b/nodejs/v10-community/istio-routing/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v10-community/istio-security/booster.yaml
+++ b/nodejs/v10-community/istio-security/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v8-community/istio-circuit-breaker/booster.yaml
+++ b/nodejs/v8-community/istio-circuit-breaker/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v1.0.1
+        ref: v1.1.0
   production:
     source:
       git:
-        ref: v1.0.1
+        ref: v1.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v8-community/istio-distributed-tracing/booster.yaml
+++ b/nodejs/v8-community/istio-distributed-tracing/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0
   production:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v8-community/istio-routing/booster.yaml
+++ b/nodejs/v8-community/istio-routing/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v1.0.1
+        ref: v1.1.0
   production:
     source:
       git:
-        ref: v1.0.1
+        ref: v1.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v8-community/istio-security/booster.yaml
+++ b/nodejs/v8-community/istio-security/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0
   production:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0
 metadata:
   app:
     launcher:


### PR DESCRIPTION
These updated versions use Istio 0.8.0