### PR TITLE
Update Vert.x boosters

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -95,9 +95,9 @@ runtimes:
     pipelinePlatform: maven
   versions:
   - id: redhat
-    name: 3.5.1.redhat-004 (RHOAR)
+    name: 3.5.3.redhat-0001 (RHOAR)
   - id: community
-    name: 3.5.2.Final (Community)
+    name: 3.5.3.Final (Community)
 - id: fuse
   name: Fuse
   description: The Fuse runtime enables you to deploy Spring Boot applications on

--- a/vert.x/community/cache/booster.yaml
+++ b/vert.x/community/cache/booster.yaml
@@ -11,8 +11,8 @@ environment:
   staging:
     source:
       git:
-        ref: v3
+        ref: v4
   production:
     source:
       git:
-        ref: v3
+        ref: v4

--- a/vert.x/community/circuit-breaker/booster.yaml
+++ b/vert.x/community/circuit-breaker/booster.yaml
@@ -13,8 +13,8 @@ environment:
   staging:
     source:
       git:
-        ref: v18
+        ref: v19
   production:
     source:
       git:
-        ref: v18    
+        ref: v19    

--- a/vert.x/community/configmap/booster.yaml
+++ b/vert.x/community/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v28
+        ref: v29
   production:
     source:
       git:
-        ref: v28
+        ref: v29

--- a/vert.x/community/crud/booster.yaml
+++ b/vert.x/community/crud/booster.yaml
@@ -13,8 +13,8 @@ environment:
   staging:
     source:
       git:
-        ref: v26
+        ref: v27
   production:
     source:
       git:
-        ref: v26
+        ref: v27

--- a/vert.x/community/health-check/booster.yaml
+++ b/vert.x/community/health-check/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v22
+        ref: v23
   production:
     source:
       git:
-        ref: v22
+        ref: v23

--- a/vert.x/community/istio-circuit-breaker/booster.yaml
+++ b/vert.x/community/istio-circuit-breaker/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v1
+        ref: v2
   production:
     source:
       git:
-        ref: v1
+        ref: v2
 metadata:
   app:
     launcher:

--- a/vert.x/community/istio-distributed-tracing/booster.yaml
+++ b/vert.x/community/istio-distributed-tracing/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v1.0
+        ref: v2
   production:
     source:
       git:
-        ref: v1.0
+        ref: v2
 metadata:
   app:
     launcher:

--- a/vert.x/community/istio-security/booster.yaml
+++ b/vert.x/community/istio-security/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v1
+        ref: v2
   production:
     source:
       git:
-        ref: v1
+        ref: v2
 metadata:
   app:
     launcher:

--- a/vert.x/community/rest-http-secured/booster.yaml
+++ b/vert.x/community/rest-http-secured/booster.yaml
@@ -12,8 +12,8 @@ environment:
   staging:
     source:
       git:
-        ref: v20
+        ref: v21
   production:
     source:
       git:
-        ref: v20
+        ref: v21

--- a/vert.x/community/rest-http/booster.yaml
+++ b/vert.x/community/rest-http/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v27
+        ref: v28
   production:
     source:
       git:
-        ref: v27
+        ref: v28

--- a/vert.x/redhat/cache/booster.yaml
+++ b/vert.x/redhat/cache/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v4
+        ref: v5
   production:
     source:
       git:
-        ref: v4
+        ref: v5

--- a/vert.x/redhat/circuit-breaker/booster.yaml
+++ b/vert.x/redhat/circuit-breaker/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v14
+        ref: v15
   production:
     source:
       git:
-        ref: v14
+        ref: v15

--- a/vert.x/redhat/configmap/booster.yaml
+++ b/vert.x/redhat/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v17
+        ref: v18
   production:
     source:
       git:
-        ref: v17
+        ref: v18

--- a/vert.x/redhat/crud/booster.yaml
+++ b/vert.x/redhat/crud/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v14
+        ref: v15
   production:
     source:
       git:
-        ref: v14
+        ref: v15

--- a/vert.x/redhat/health-check/booster.yaml
+++ b/vert.x/redhat/health-check/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v15
+        ref: v16
   production:
     source:
       git:
-        ref: v15
+        ref: v16

--- a/vert.x/redhat/rest-http-secured/booster.yaml
+++ b/vert.x/redhat/rest-http-secured/booster.yaml
@@ -14,8 +14,8 @@ environment:
   staging:
     source:
       git:
-        ref: v21
+        ref: v22
   production:
     source:
       git:
-        ref: v21
+        ref: v22

--- a/vert.x/redhat/rest-http/booster.yaml
+++ b/vert.x/redhat/rest-http/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v15
+        ref: v16
   production:
     source:
       git:
-        ref: v15
+        ref: v16


### PR DESCRIPTION
Are updated in this PR:
* community booster to Vert.x 3.5.3
* boosters using productized version of the runtime 3.5.3-redhat-0001
* Vert.x Istio boosters  to Vert.x 3.5.3

