### PR TITLE
Bump Vert.x booster versions

### DIFF
--- a/vert.x/community/cache/booster.yaml
+++ b/vert.x/community/cache/booster.yaml
@@ -11,8 +11,8 @@ environment:
   staging:
     source:
       git:
-        ref: v4
+        ref: v5
   production:
     source:
       git:
-        ref: v4
+        ref: v5

--- a/vert.x/community/circuit-breaker/booster.yaml
+++ b/vert.x/community/circuit-breaker/booster.yaml
@@ -13,8 +13,8 @@ environment:
   staging:
     source:
       git:
-        ref: v19
+        ref: v20
   production:
     source:
       git:
-        ref: v19    
+        ref: v20    

--- a/vert.x/community/configmap/booster.yaml
+++ b/vert.x/community/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v29
+        ref: v30
   production:
     source:
       git:
-        ref: v29
+        ref: v30

--- a/vert.x/community/crud/booster.yaml
+++ b/vert.x/community/crud/booster.yaml
@@ -13,8 +13,8 @@ environment:
   staging:
     source:
       git:
-        ref: v27
+        ref: v28
   production:
     source:
       git:
-        ref: v27
+        ref: v28

--- a/vert.x/community/health-check/booster.yaml
+++ b/vert.x/community/health-check/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v23
+        ref: v24
   production:
     source:
       git:
-        ref: v23
+        ref: v24

--- a/vert.x/community/rest-http-secured/booster.yaml
+++ b/vert.x/community/rest-http-secured/booster.yaml
@@ -12,8 +12,8 @@ environment:
   staging:
     source:
       git:
-        ref: v21
+        ref: v22
   production:
     source:
       git:
-        ref: v21
+        ref: v22

--- a/vert.x/community/rest-http/booster.yaml
+++ b/vert.x/community/rest-http/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v28
+        ref: v29
   production:
     source:
       git:
-        ref: v28
+        ref: v29

--- a/vert.x/redhat/cache/booster.yaml
+++ b/vert.x/redhat/cache/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v5
+        ref: v6
   production:
     source:
       git:
-        ref: v5
+        ref: v6

--- a/vert.x/redhat/circuit-breaker/booster.yaml
+++ b/vert.x/redhat/circuit-breaker/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v15
+        ref: v16
   production:
     source:
       git:
-        ref: v15
+        ref: v16

--- a/vert.x/redhat/configmap/booster.yaml
+++ b/vert.x/redhat/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v18
+        ref: v19
   production:
     source:
       git:
-        ref: v18
+        ref: v19

--- a/vert.x/redhat/crud/booster.yaml
+++ b/vert.x/redhat/crud/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v15
+        ref: v16
   production:
     source:
       git:
-        ref: v15
+        ref: v16

--- a/vert.x/redhat/health-check/booster.yaml
+++ b/vert.x/redhat/health-check/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v16
+        ref: v17
   production:
     source:
       git:
-        ref: v16
+        ref: v17

--- a/vert.x/redhat/rest-http-secured/booster.yaml
+++ b/vert.x/redhat/rest-http-secured/booster.yaml
@@ -14,8 +14,8 @@ environment:
   staging:
     source:
       git:
-        ref: v22
+        ref: v23
   production:
     source:
       git:
-        ref: v22
+        ref: v23

--- a/vert.x/redhat/rest-http/booster.yaml
+++ b/vert.x/redhat/rest-http/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v16
+        ref: v17
   production:
     source:
       git:
-        ref: v16
+        ref: v17


### PR DESCRIPTION
This PR updates the Vert.x booster versions and fix the broken template generation.

Now the templates are tested as part of our CI jobs, so we should not have such kind of issues anymore.... well, in theory. 