### PR TITLE
chore: update Node istio circuit breaker boosters to the latest.

### DIFF
--- a/nodejs/v10-community/istio-circuit-breaker/booster.yaml
+++ b/nodejs/v10-community/istio-circuit-breaker/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v2.2.0
+        ref: v2.2.1
   production:
     source:
       git:
-        ref: v2.2.0
+        ref: v2.2.1
 metadata:
   app:
     launcher:

--- a/nodejs/v10-redhat/istio-circuit-breaker/booster.yaml
+++ b/nodejs/v10-redhat/istio-circuit-breaker/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1
 metadata:
   app:
     launcher:

--- a/nodejs/v8-community/istio-circuit-breaker/booster.yaml
+++ b/nodejs/v8-community/istio-circuit-breaker/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v1.2.0
+        ref: v1.2.1
   production:
     source:
       git:
-        ref: v1.2.0
+        ref: v1.2.1
 metadata:
   app:
     launcher:

--- a/nodejs/v8-redhat/istio-circuit-breaker/booster.yaml
+++ b/nodejs/v8-redhat/istio-circuit-breaker/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.0.1
   production:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.0.1
 metadata:
   app:
     launcher:


### PR DESCRIPTION
This update includes fixes for https://issues.jboss.org/browse/NODE-222