### PR TITLE
chore: update node.js booster git locations.

### DIFF
--- a/nodejs/v10-community/cache/booster.yaml
+++ b/nodejs/v10-community/cache/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js Cache Booster
 description: Demonstrate how to use a cache server from a Node.js application
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-cache
+    url: https://github.com/nodeshift-starters/nodejs-cache
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.1.0
+        ref: v2.2.0
   production:
     source:
       git:
-        ref: v2.1.0
+        ref: v2.2.0

--- a/nodejs/v10-community/circuit-breaker/booster.yaml
+++ b/nodejs/v10-community/circuit-breaker/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js - Circuit Breaker
 description: Demonstrates Circuit Breaker in Node.js
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-circuit-breaker
+    url: https://github.com/nodeshift-starters/nodejs-circuit-breaker
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0

--- a/nodejs/v10-community/configmap/booster.yaml
+++ b/nodejs/v10-community/configmap/booster.yaml
@@ -2,14 +2,14 @@ name: Node.js - HTTP & Config Map
 description: Simple HTTP endpoint where the Node.js application uses OpenShift ConfigMap to get the application parameters.
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-configmap
+    url: https://github.com/nodeshift-starters/nodejs-configmap
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1

--- a/nodejs/v10-community/crud/booster.yaml
+++ b/nodejs/v10-community/crud/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js - CRUD Example
 description: Runs a Node.js application exposing a HTTP endpoint proposing CRUD operations
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-rest-http-crud
+    url: https://github.com/nodeshift-starters/nodejs-rest-http-crud
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0

--- a/nodejs/v10-community/health-check/booster.yaml
+++ b/nodejs/v10-community/health-check/booster.yaml
@@ -2,14 +2,14 @@ name: Node.js - Health Checks
 description: Demonstrates Health Checks in Node.js
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-health-check
+    url: https://github.com/nodeshift-starters/nodejs-health-check
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1

--- a/nodejs/v10-community/istio-circuit-breaker/booster.yaml
+++ b/nodejs/v10-community/istio-circuit-breaker/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Circuit Breaker
 description: Runs a Node.js application that utilizes Circuit Breakers on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-circuit-breaker
+    url: https://github.com/nodeshift-starters/nodejs-istio-circuit-breaker
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.2.1
+        ref: v2.3.0
   production:
     source:
       git:
-        ref: v2.2.1
+        ref: v2.3.0
 metadata:
   app:
     launcher:

--- a/nodejs/v10-community/istio-distributed-tracing/booster.yaml
+++ b/nodejs/v10-community/istio-distributed-tracing/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Distributed Tracing
 description: Runs a Node.js application that utilizes Tracing on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-tracing
+    url: https://github.com/nodeshift-starters/nodejs-istio-tracing
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.1.0
+        ref: v2.2.0
   production:
     source:
       git:
-        ref: v2.1.0
+        ref: v2.2.0
 metadata:
   app:
     launcher:

--- a/nodejs/v10-community/istio-routing/booster.yaml
+++ b/nodejs/v10-community/istio-routing/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Routing
 description: Runs a Node.js application that utilizes Routing on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-routing
+    url: https://github.com/nodeshift-starters/nodejs-istio-routing
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.1.0
+        ref: v2.2.0
   production:
     source:
       git:
-        ref: v2.1.0
+        ref: v2.2.0
 metadata:
   app:
     launcher:

--- a/nodejs/v10-community/istio-security/booster.yaml
+++ b/nodejs/v10-community/istio-security/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Security
 description: Runs a Node.js application that showcases security through Mutual TLS and ACL on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-security
+    url: https://github.com/nodeshift-starters/nodejs-istio-security
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.1.0
+        ref: v2.2.0
   production:
     source:
       git:
-        ref: v2.1.0
+        ref: v2.2.0
 metadata:
   app:
     launcher:

--- a/nodejs/v10-community/messaging/booster.yaml
+++ b/nodejs/v10-community/messaging/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js Messaging Booster
 description: Demonstrate how to use a Messaging Work Queue from a Node.js application
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-messaging-work-queue
+    url: https://github.com/nodeshift-starters/nodejs-messaging-work-queue
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0

--- a/nodejs/v10-community/rest-http-secured/booster.yaml
+++ b/nodejs/v10-community/rest-http-secured/booster.yaml
@@ -6,14 +6,14 @@ name: Node.js - REST and RH SSO
 description: A simple HTTP application using Node.js secured by RH SSO
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-rest-http-secured
+    url: https://github.com/nodeshift-starters/nodejs-rest-http-secured
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1

--- a/nodejs/v10-community/rest-http/booster.yaml
+++ b/nodejs/v10-community/rest-http/booster.yaml
@@ -2,14 +2,14 @@ name: Node.js - HTTP
 description: Runs a Node.js HTTP application
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-rest-http
+    url: https://github.com/nodeshift-starters/nodejs-rest-http
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1

--- a/nodejs/v10-redhat/cache/booster.yaml
+++ b/nodejs/v10-redhat/cache/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js Cache Booster
 description: Demonstrate how to use a cache server from a Node.js application
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-cache-redhat
+    url: https://github.com/nodeshift-starters/nodejs-cache-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.1.0
+        ref: v2.2.0
   production:
     source:
       git:
-        ref: v2.1.0
+        ref: v2.2.0

--- a/nodejs/v10-redhat/circuit-breaker/booster.yaml
+++ b/nodejs/v10-redhat/circuit-breaker/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js - Circuit Breaker
 description: Demonstrates Circuit Breaker in Node.js
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-circuit-breaker-redhat
+    url: https://github.com/nodeshift-starters/nodejs-circuit-breaker-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0

--- a/nodejs/v10-redhat/configmap/booster.yaml
+++ b/nodejs/v10-redhat/configmap/booster.yaml
@@ -2,14 +2,14 @@ name: Node.js - HTTP & Config Map
 description: Simple HTTP endpoint where the Node.js application uses OpenShift ConfigMap to get the application parameters.
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-configmap-redhat
+    url: https://github.com/nodeshift-starters/nodejs-configmap-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1

--- a/nodejs/v10-redhat/crud/booster.yaml
+++ b/nodejs/v10-redhat/crud/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js - CRUD Example
 description: Runs a Node.js application exposing a HTTP endpoint proposing CRUD operations
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-rest-http-crud-redhat
+    url: https://github.com/nodeshift-starters/nodejs-rest-http-crud-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1

--- a/nodejs/v10-redhat/health-check/booster.yaml
+++ b/nodejs/v10-redhat/health-check/booster.yaml
@@ -2,14 +2,14 @@ name: Node.js - Health Checks
 description: Demonstrates Health Checks in Node.js
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-health-check-redhat
+    url: https://github.com/nodeshift-starters/nodejs-health-check-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1

--- a/nodejs/v10-redhat/istio-circuit-breaker/booster.yaml
+++ b/nodejs/v10-redhat/istio-circuit-breaker/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Circuit Breaker
 description: Runs a Node.js application that utilizes Circuit Breakers on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-circuit-breaker-redhat
+    url: https://github.com/nodeshift-starters/nodejs-istio-circuit-breaker-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v10-redhat/istio-distributed-tracing/booster.yaml
+++ b/nodejs/v10-redhat/istio-distributed-tracing/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Distributed Tracing
 description: Runs a Node.js application that utilizes Tracing on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-tracing-redhat
+    url: https://github.com/nodeshift-starters/nodejs-istio-tracing-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v10-redhat/istio-routing/booster.yaml
+++ b/nodejs/v10-redhat/istio-routing/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Routing
 description: Runs a Node.js application that utilizes Routing on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-routing-redhat
+    url: https://github.com/nodeshift-starters/nodejs-istio-routing-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v10-redhat/istio-security/booster.yaml
+++ b/nodejs/v10-redhat/istio-security/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Security
 description: Runs a Node.js application that showcases security through Mutual TLS and ACL on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-security-redhat
+    url: https://github.com/nodeshift-starters/nodejs-istio-security-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v10-redhat/messaging/booster.yaml
+++ b/nodejs/v10-redhat/messaging/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js Messaging Booster
 description: Demonstrate how to use a Messaging Work Queue from a Node.js application
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-messaging-work-queue-redhat
+    url: https://github.com/nodeshift-starters/nodejs-messaging-work-queue-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.1.0

--- a/nodejs/v10-redhat/rest-http-secured/booster.yaml
+++ b/nodejs/v10-redhat/rest-http-secured/booster.yaml
@@ -6,14 +6,14 @@ name: Node.js - REST and RH SSO
 description: A simple HTTP application using Node.js secured by RH SSO
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-rest-http-secured-redhat
+    url: https://github.com/nodeshift-starters/nodejs-rest-http-secured-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.1

--- a/nodejs/v10-redhat/rest-http/booster.yaml
+++ b/nodejs/v10-redhat/rest-http/booster.yaml
@@ -2,14 +2,14 @@ name: Node.js - HTTP
 description: Runs a Node.js HTTP application
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-rest-http-redhat
+    url: https://github.com/nodeshift-starters/nodejs-rest-http-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.2
   production:
     source:
       git:
-        ref: v2.0.0
+        ref: v2.0.2

--- a/nodejs/v8-community/cache/booster.yaml
+++ b/nodejs/v8-community/cache/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js Cache Booster
 description: Demonstrate how to use a cache server from a Node.js application
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-cache
+    url: https://github.com/nodeshift-starters/nodejs-cache
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.1.0
+        ref: v1.2.0
   production:
     source:
       git:
-        ref: v1.1.0
+        ref: v1.2.0

--- a/nodejs/v8-community/circuit-breaker/booster.yaml
+++ b/nodejs/v8-community/circuit-breaker/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js - Circuit Breaker
 description: Demonstrates Circuit Breaker in Node.js
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-circuit-breaker
+    url: https://github.com/nodeshift-starters/nodejs-circuit-breaker
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.1.3
+        ref: v1.2.0
   production:
     source:
       git:
-        ref: v1.1.3
+        ref: v1.2.0

--- a/nodejs/v8-community/configmap/booster.yaml
+++ b/nodejs/v8-community/configmap/booster.yaml
@@ -2,14 +2,14 @@ name: Node.js - HTTP & Config Map
 description: Simple HTTP endpoint where the Node.js application uses OpenShift ConfigMap to get the application parameters.
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-configmap
+    url: https://github.com/nodeshift-starters/nodejs-configmap
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.2.3
+        ref: v1.2.4
   production:
     source:
       git:
-        ref: v1.2.3
+        ref: v1.2.4

--- a/nodejs/v8-community/crud/booster.yaml
+++ b/nodejs/v8-community/crud/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js - CRUD Example
 description: Runs a Node.js application exposing a HTTP endpoint proposing CRUD operations
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-rest-http-crud
+    url: https://github.com/nodeshift-starters/nodejs-rest-http-crud
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.2.3
+        ref: v1.3.0
   production:
     source:
       git:
-        ref: v1.2.3
+        ref: v1.3.0

--- a/nodejs/v8-community/health-check/booster.yaml
+++ b/nodejs/v8-community/health-check/booster.yaml
@@ -2,14 +2,14 @@ name: Node.js - Health Checks
 description: Demonstrates Health Checks in Node.js
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-health-check
+    url: https://github.com/nodeshift-starters/nodejs-health-check
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.2.3
+        ref: v1.3.1
   production:
     source:
       git:
-        ref: v1.2.3
+        ref: v1.3.1

--- a/nodejs/v8-community/istio-circuit-breaker/booster.yaml
+++ b/nodejs/v8-community/istio-circuit-breaker/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Circuit Breaker
 description: Runs a Node.js application that utilizes Circuit Breakers on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-circuit-breaker
+    url: https://github.com/nodeshift-starters/nodejs-istio-circuit-breaker
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.2.1
+        ref: v1.3.0
   production:
     source:
       git:
-        ref: v1.2.1
+        ref: v1.3.0
 metadata:
   app:
     launcher:

--- a/nodejs/v8-community/istio-distributed-tracing/booster.yaml
+++ b/nodejs/v8-community/istio-distributed-tracing/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Distributed Tracing
 description: Runs a Node.js application that utilizes Tracing on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-tracing
+    url: https://github.com/nodeshift-starters/nodejs-istio-tracing
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.1.0
+        ref: v1.2.0
   production:
     source:
       git:
-        ref: v1.1.0
+        ref: v1.2.0
 metadata:
   app:
     launcher:

--- a/nodejs/v8-community/istio-routing/booster.yaml
+++ b/nodejs/v8-community/istio-routing/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Routing
 description: Runs a Node.js application that utilizes Routing on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-routing
+    url: https://github.com/nodeshift-starters/nodejs-istio-routing
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.1.0
+        ref: v1.2.0
   production:
     source:
       git:
-        ref: v1.1.0
+        ref: v1.2.0
 metadata:
   app:
     launcher:

--- a/nodejs/v8-community/istio-security/booster.yaml
+++ b/nodejs/v8-community/istio-security/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Security
 description: Runs a Node.js application that showcases security through Mutual TLS and ACL on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-security
+    url: https://github.com/nodeshift-starters/nodejs-istio-security
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.1.0
+        ref: v1.2.0
   production:
     source:
       git:
-        ref: v1.1.0
+        ref: v1.2.0
 metadata:
   app:
     launcher:

--- a/nodejs/v8-community/messaging/booster.yaml
+++ b/nodejs/v8-community/messaging/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js Messaging Booster
 description: Demonstrate how to use a Messaging Work Queue from a Node.js application
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-messaging-work-queue
+    url: https://github.com/nodeshift-starters/nodejs-messaging-work-queue
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0
   production:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0

--- a/nodejs/v8-community/rest-http-secured/booster.yaml
+++ b/nodejs/v8-community/rest-http-secured/booster.yaml
@@ -6,14 +6,14 @@ name: Node.js - REST and RH SSO
 description: A simple HTTP application using Node.js secured by RH SSO
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-rest-http-secured
+    url: https://github.com/nodeshift-starters/nodejs-rest-http-secured
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.1.4
+        ref: v1.2.0
   production:
     source:
       git:
-        ref: v1.1.4
+        ref: v1.2.0

--- a/nodejs/v8-community/rest-http/booster.yaml
+++ b/nodejs/v8-community/rest-http/booster.yaml
@@ -2,14 +2,14 @@ name: Node.js - HTTP
 description: Runs a Node.js HTTP application
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-rest-http
+    url: https://github.com/nodeshift-starters/nodejs-rest-http
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.2.3
+        ref: v1.2.4
   production:
     source:
       git:
-        ref: v1.2.3
+        ref: v1.2.4

--- a/nodejs/v8-redhat/cache/booster.yaml
+++ b/nodejs/v8-redhat/cache/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js Cache Booster
 description: Demonstrate how to use a cache server from a Node.js application
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-cache-redhat
+    url: https://github.com/nodeshift-starters/nodejs-cache-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.1.0
+        ref: v1.2.0
   production:
     source:
       git:
-        ref: v1.1.0
+        ref: v1.2.0

--- a/nodejs/v8-redhat/circuit-breaker/booster.yaml
+++ b/nodejs/v8-redhat/circuit-breaker/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js - Circuit Breaker
 description: Demonstrates Circuit Breaker in Node.js
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-circuit-breaker-redhat
+    url: https://github.com/nodeshift-starters/nodejs-circuit-breaker-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.1.2
+        ref: v1.2.0
   production:
     source:
       git:
-        ref: v1.1.2
+        ref: v1.2.0

--- a/nodejs/v8-redhat/configmap/booster.yaml
+++ b/nodejs/v8-redhat/configmap/booster.yaml
@@ -2,14 +2,14 @@ name: Node.js - HTTP & Config Map
 description: Simple HTTP endpoint where the Node.js application uses OpenShift ConfigMap to get the application parameters.
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-configmap-redhat
+    url: https://github.com/nodeshift-starters/nodejs-configmap-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.2.2
+        ref: v1.2.3
   production:
     source:
       git:
-        ref: v1.2.2
+        ref: v1.2.3

--- a/nodejs/v8-redhat/crud/booster.yaml
+++ b/nodejs/v8-redhat/crud/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js - CRUD Example
 description: Runs a Node.js application exposing a HTTP endpoint proposing CRUD operations
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-rest-http-crud-redhat
+    url: https://github.com/nodeshift-starters/nodejs-rest-http-crud-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.2.2
+        ref: v1.2.3
   production:
     source:
       git:
-        ref: v1.2.2
+        ref: v1.2.3

--- a/nodejs/v8-redhat/health-check/booster.yaml
+++ b/nodejs/v8-redhat/health-check/booster.yaml
@@ -2,14 +2,14 @@ name: Node.js - Health Checks
 description: Demonstrates Health Checks in Node.js
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-health-check-redhat
+    url: https://github.com/nodeshift-starters/nodejs-health-check-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.2.2
+        ref: v1.2.3
   production:
     source:
       git:
-        ref: v1.2.2
+        ref: v1.2.3

--- a/nodejs/v8-redhat/istio-circuit-breaker/booster.yaml
+++ b/nodejs/v8-redhat/istio-circuit-breaker/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Circuit Breaker
 description: Runs a Node.js application that utilizes Circuit Breakers on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-circuit-breaker-redhat
+    url: https://github.com/nodeshift-starters/nodejs-istio-circuit-breaker-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.0.1
+        ref: v1.1.0
   production:
     source:
       git:
-        ref: v1.0.1
+        ref: v1.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v8-redhat/istio-distributed-tracing/booster.yaml
+++ b/nodejs/v8-redhat/istio-distributed-tracing/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Distributed Tracing
 description: Runs a Node.js application that utilizes Tracing on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-tracing-redhat
+    url: https://github.com/nodeshift-starters/nodejs-istio-tracing-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0
   production:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v8-redhat/istio-routing/booster.yaml
+++ b/nodejs/v8-redhat/istio-routing/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Routing
 description: Runs a Node.js application that utilizes Routing on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-routing-redhat
+    url: https://github.com/nodeshift-starters/nodejs-istio-routing-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0
   production:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v8-redhat/istio-security/booster.yaml
+++ b/nodejs/v8-redhat/istio-security/booster.yaml
@@ -2,17 +2,17 @@ name: Node.js - Istio - Security
 description: Runs a Node.js application that showcases security through Mutual TLS and ACL on Istio
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-istio-security-redhat
+    url: https://github.com/nodeshift-starters/nodejs-istio-security-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0
   production:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0
 metadata:
   app:
     launcher:

--- a/nodejs/v8-redhat/messaging/booster.yaml
+++ b/nodejs/v8-redhat/messaging/booster.yaml
@@ -7,14 +7,14 @@ name: Node.js Messaging Booster
 description: Demonstrate how to use a Messaging Work Queue from a Node.js application
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-messaging-work-queue-redhat
+    url: https://github.com/nodeshift-starters/nodejs-messaging-work-queue-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0
   production:
     source:
       git:
-        ref: v1.0.0
+        ref: v1.1.0

--- a/nodejs/v8-redhat/rest-http-secured/booster.yaml
+++ b/nodejs/v8-redhat/rest-http-secured/booster.yaml
@@ -12,8 +12,8 @@ environment:
   staging:
     source:
       git:
-        ref: v1.2.0
+        ref: v1.1.3
   production:
     source:
       git:
-        ref: v1.2.0
+        ref: v1.1.3

--- a/nodejs/v8-redhat/rest-http-secured/booster.yaml
+++ b/nodejs/v8-redhat/rest-http-secured/booster.yaml
@@ -6,14 +6,14 @@ name: Node.js - REST and RH SSO
 description: A simple HTTP application using Node.js secured by RH SSO
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-rest-http-secured-redhat
+    url: https://github.com/nodeshift-starters/nodejs-rest-http-secured-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.1.2
+        ref: v1.2.0
   production:
     source:
       git:
-        ref: v1.1.2
+        ref: v1.2.0

--- a/nodejs/v8-redhat/rest-http/booster.yaml
+++ b/nodejs/v8-redhat/rest-http/booster.yaml
@@ -2,14 +2,14 @@ name: Node.js - HTTP
 description: Runs a Node.js HTTP application
 source:
   git:
-    url: https://github.com/bucharest-gold/nodejs-rest-http-redhat
+    url: https://github.com/nodeshift-starters/nodejs-rest-http-redhat
     ref: master
 environment:
   staging:
     source:
       git:
-        ref: v1.2.3
+        ref: v1.2.5
   production:
     source:
       git:
-        ref: v1.2.3
+        ref: v1.2.5


### PR DESCRIPTION
We are no longer using bucharest-gold as a project name.  The new name is Nodeshift and the new repo location for these applications is nodeshift-starters