### PR TITLE
chore: update nodejs config map versions

### DIFF
--- a/nodejs/v10-community/configmap/booster.yaml
+++ b/nodejs/v10-community/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.1.0

--- a/nodejs/v10-redhat/configmap/booster.yaml
+++ b/nodejs/v10-redhat/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.1.0

--- a/nodejs/v8-community/configmap/booster.yaml
+++ b/nodejs/v8-community/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v1.2.4
+        ref: v1.3.0
   production:
     source:
       git:
-        ref: v1.2.4
+        ref: v1.3.0

--- a/nodejs/v8-redhat/configmap/booster.yaml
+++ b/nodejs/v8-redhat/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v1.2.3
+        ref: v1.3.0
   production:
     source:
       git:
-        ref: v1.2.3
+        ref: v1.3.0


### PR DESCRIPTION
These new versions use volume mounts to expose the config maps to the application.  Inline with how the other runtimes are doing it