### PR TITLE
enabling community nodejs v10 healthcheck and http

### DIFF
--- a/nodejs/v10-community/health-check/booster.yaml
+++ b/nodejs/v10-community/health-check/booster.yaml
@@ -4,6 +4,10 @@ source:
   git:
     url: https://github.com/nodeshift-starters/nodejs-health-check
     ref: master
+metadata:
+  app:
+    osio:
+      enabled: true
 environment:
   staging:
     source:

--- a/nodejs/v10-community/rest-http/booster.yaml
+++ b/nodejs/v10-community/rest-http/booster.yaml
@@ -4,6 +4,10 @@ source:
   git:
     url: https://github.com/nodeshift-starters/nodejs-rest-http
     ref: master
+metadata:
+  app:
+    osio:
+      enabled: true
 environment:
   staging:
     source:


### PR DESCRIPTION
This enables community nodejs health-check and http
![screenshot from 2018-11-21 12-10-22](https://user-images.githubusercontent.com/40298444/48858753-2c577900-ed8a-11e8-8aa7-c78e67afc72c.png)



When testing locally, i noticed that I was stuck on the dependency screen. The dependency screen states that i need to select a runtime and mission - even though I have already done so. If you skip the dependency screen and make it to the end of the process, you cannot complete the process. It says the process is incomplete. When selecting the "incomplete" button, I am guided back to the start of the process to select a runtime and mission. Upon trying again, when I reached the github part of the process I was unable to click the arrows to continue. The screenshot shows the redhat version instead of the community version, but both were tested and both resulted in the same problem.
![screenshot from 2018-11-21 11-59-30](https://user-images.githubusercontent.com/40298444/48858738-1ea1f380-ed8a-11e8-9edf-cba0ed27343f.png)
