### PR TITLE
Update Vert.x boosters

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -101,7 +101,7 @@ runtimes:
       - id: redhat
         name: 3.5.4.redhat-00002 (RHOAR)
       - id: community
-        name: 3.5.4 (Community)
+        name: 3.6.2 (Community)
   - id: fuse
     name: Fuse
     description: >-

--- a/vert.x/community/cache/booster.yaml
+++ b/vert.x/community/cache/booster.yaml
@@ -11,8 +11,8 @@ environment:
   staging:
     source:
       git:
-        ref: v6
+        ref: v7
   production:
     source:
       git:
-        ref: v6
+        ref: v7

--- a/vert.x/community/circuit-breaker/booster.yaml
+++ b/vert.x/community/circuit-breaker/booster.yaml
@@ -13,8 +13,8 @@ environment:
   staging:
     source:
       git:
-        ref: v21
+        ref: v22
   production:
     source:
       git:
-        ref: v21 
+        ref: v22 

--- a/vert.x/community/configmap/booster.yaml
+++ b/vert.x/community/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v31
+        ref: v32
   production:
     source:
       git:
-        ref: v31
+        ref: v32

--- a/vert.x/community/crud/booster.yaml
+++ b/vert.x/community/crud/booster.yaml
@@ -13,8 +13,8 @@ environment:
   staging:
     source:
       git:
-        ref: v29
+        ref: v30
   production:
     source:
       git:
-        ref: v29
+        ref: v30

--- a/vert.x/community/health-check/booster.yaml
+++ b/vert.x/community/health-check/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v25
+        ref: v26
   production:
     source:
       git:
-        ref: v25
+        ref: v26

--- a/vert.x/community/istio-circuit-breaker/booster.yaml
+++ b/vert.x/community/istio-circuit-breaker/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v2
+        ref: v3
   production:
     source:
       git:
-        ref: v2
+        ref: v3
 metadata:
   app:
     launcher:

--- a/vert.x/community/istio-distributed-tracing/booster.yaml
+++ b/vert.x/community/istio-distributed-tracing/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v2
+        ref: v3
   production:
     source:
       git:
-        ref: v2
+        ref: v3
 metadata:
   app:
     launcher:

--- a/vert.x/community/istio-routing/booster.yaml
+++ b/vert.x/community/istio-routing/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v2
+        ref: v3
   production:
     source:
       git:
-        ref: v2
+        ref: v3
 metadata:
   app:
     launcher:

--- a/vert.x/community/istio-security/booster.yaml
+++ b/vert.x/community/istio-security/booster.yaml
@@ -8,11 +8,11 @@ environment:
   staging:
     source:
       git:
-        ref: v2
+        ref: v3
   production:
     source:
       git:
-        ref: v2
+        ref: v3
 metadata:
   app:
     launcher:

--- a/vert.x/community/rest-http-secured/booster.yaml
+++ b/vert.x/community/rest-http-secured/booster.yaml
@@ -12,8 +12,8 @@ environment:
   staging:
     source:
       git:
-        ref: v23
+        ref: v24
   production:
     source:
       git:
-        ref: v23
+        ref: v24

--- a/vert.x/community/rest-http/booster.yaml
+++ b/vert.x/community/rest-http/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v30
+        ref: v31
   production:
     source:
       git:
-        ref: v30
+        ref: v31

--- a/vert.x/redhat/cache/booster.yaml
+++ b/vert.x/redhat/cache/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v7
+        ref: v8
   production:
     source:
       git:
-        ref: v7
+        ref: v8

--- a/vert.x/redhat/circuit-breaker/booster.yaml
+++ b/vert.x/redhat/circuit-breaker/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v17
+        ref: v18
   production:
     source:
       git:
-        ref: v17
+        ref: v18

--- a/vert.x/redhat/configmap/booster.yaml
+++ b/vert.x/redhat/configmap/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v20
+        ref: v21
   production:
     source:
       git:
-        ref: v20
+        ref: v21

--- a/vert.x/redhat/crud/booster.yaml
+++ b/vert.x/redhat/crud/booster.yaml
@@ -15,8 +15,8 @@ environment:
   staging:
     source:
       git:
-        ref: v17
+        ref: v18
   production:
     source:
       git:
-        ref: v17
+        ref: v18

--- a/vert.x/redhat/health-check/booster.yaml
+++ b/vert.x/redhat/health-check/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v18
+        ref: v19
   production:
     source:
       git:
-        ref: v18
+        ref: v19

--- a/vert.x/redhat/rest-http-secured/booster.yaml
+++ b/vert.x/redhat/rest-http-secured/booster.yaml
@@ -14,8 +14,8 @@ environment:
   staging:
     source:
       git:
-        ref: v24
+        ref: v25
   production:
     source:
       git:
-        ref: v24
+        ref: v25

--- a/vert.x/redhat/rest-http/booster.yaml
+++ b/vert.x/redhat/rest-http/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v18
+        ref: v19
   production:
     source:
       git:
-        ref: v18
+        ref: v19


### PR DESCRIPTION
* Update community booster to 3.6.2
* All boosters are now parent-less (including productized)
* Update istio boosters
* All booster use the new Vert.x maven plugin