### PR TITLE
chore: update nodejs-rest-http booster to version 2.1.0 and 1.3.0 for…

### DIFF
--- a/nodejs/v10-community/rest-http/booster.yaml
+++ b/nodejs/v10-community/rest-http/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.1.0
   production:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.1.0

--- a/nodejs/v8-community/rest-http/booster.yaml
+++ b/nodejs/v8-community/rest-http/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v1.2.4
+        ref: v1.3.0
   production:
     source:
       git:
-        ref: v1.2.4
+        ref: v1.3.0


### PR DESCRIPTION
… community

* This version adds the RELEASE_VERSION param