### PR TITLE
Add Spring Boot messaging booster

### DIFF
--- a/spring-boot/current-community/messaging/booster.yaml
+++ b/spring-boot/current-community/messaging/booster.yaml
@@ -1,0 +1,11 @@
+metadata:
+  app:
+    launcher:
+      runsOn:
+      - '!starter'
+name: Spring Boot - Messaging Booster
+description: Demonstrate how to use a Messaging Work Queue from a Spring Boot application
+source:
+  git:
+    url: https://github.com/snowdrop/spring-boot-messaging-work-queue-booster
+    ref: 1.5.17-4

--- a/spring-boot/current-redhat/messaging/booster.yaml
+++ b/spring-boot/current-redhat/messaging/booster.yaml
@@ -1,0 +1,11 @@
+metadata:
+  app:
+    launcher:
+      runsOn:
+      - '!starter'
+name: Spring Boot - Messaging Booster
+description: Demonstrate how to use a Messaging Work Queue from a Spring Boot application
+source:
+  git:
+    url: https://github.com/snowdrop/spring-boot-messaging-work-queue-booster
+    ref: 1.5.17-4-redhat


### PR DESCRIPTION
Is it ok that a dependent service template file is named [service.yaml](https://github.com/snowdrop/spring-boot-messaging-work-queue-booster/blob/1.5.17-4/service.yaml) rather than `service.amqp.yaml` or `service.cache.yaml` like in other boosters? I can rename it for the next release.