### PR TITLE
chore: update nodejs-health-check booster to version 2.0.2 and 1.3.2 …

### DIFF
--- a/nodejs/v10-community/health-check/booster.yaml
+++ b/nodejs/v10-community/health-check/booster.yaml
@@ -12,8 +12,8 @@ environment:
   staging:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.0.2
   production:
     source:
       git:
-        ref: v2.0.1
+        ref: v2.0.2

--- a/nodejs/v8-community/health-check/booster.yaml
+++ b/nodejs/v8-community/health-check/booster.yaml
@@ -8,8 +8,8 @@ environment:
   staging:
     source:
       git:
-        ref: v1.3.1
+        ref: v1.3.2
   production:
     source:
       git:
-        ref: v1.3.1
+        ref: v1.3.2


### PR DESCRIPTION
…for community.

* Includes fixes for package-lock.jsons
* Removes nsp in favor of npm audit

should fix https://github.com/openshiftio/openshift.io/issues/4701