### PR TITLE
Clarify information about source/git/ref in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ name | The name of the Booster
 description | (Optional) A longer description for the Booster
 ignore | (Optional) Set this to "true" to have the Booster be ignored by the Launcher
 source/git/url | The Git repository location URL
-source/git/ref | The Git reference (tag/branch/SHA1)
+source/git/ref | The Git reference (tag or branch only)
 environment | (Optional) The configuration for this booster in a specific environment to be overriden from the default configuration
 metadata | (Optional) A free section where booster authors can put their own information which will be passed on to REST endpoints and the UI
 


### PR DESCRIPTION
SHA1 hash is not supported for source/git/ref value.
Updating Readme based on the discussion here: https://github.com/fabric8-launcher/launcher-booster-catalog-service/issues/31#issuecomment-474813604

ping @gastaldi 