### PR TITLE
chore: put ISTIO - Distributed Tracing back

### DIFF
--- a/fuse/community/istio-distributed-tracing/booster.yaml
+++ b/fuse/community/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,20 @@
+name: Red Hat Fuse - Istio - Distributed Tracing
+description: Runs a Apache Camel application that utilizes Tracing on Istio
+source:
+  git:
+    url: https://github.com/jboss-fuse/fuse-istio-distributed-tracing-booster
+    ref: master
+environment:
+  staging:
+    source:
+      git:
+        ref: v7.3.0
+  production:
+    source:
+      git:
+        ref: v7.3.0
+metadata:
+  app:
+    launcher:
+      runsOn:
+        - 'none'

--- a/fuse/redhat720/istio-distributed-tracing/booster.yaml
+++ b/fuse/redhat720/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,20 @@
+name: Red Hat Fuse - Istio - Distributed Tracing
+description: Runs a Apache Camel application that utilizes Tracing on Istio
+source:
+  git:
+    url: https://github.com/jboss-fuse/fuse-istio-distributed-tracing-booster
+    ref: redhat
+environment:
+  staging:
+    source:
+      git:
+        ref: v7.2.0-redhat-01
+  production:
+    source:
+      git:
+        ref: v7.2.0-redhat-01
+metadata:
+  app:
+    launcher:
+      runsOn:
+        - 'none'

--- a/fuse/redhat730/istio-distributed-tracing/booster.yaml
+++ b/fuse/redhat730/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,20 @@
+name: Red Hat Fuse - Istio - Distributed Tracing
+description: Runs a Apache Camel application that utilizes Tracing on Istio
+source:
+  git:
+    url: https://github.com/jboss-fuse/fuse-istio-distributed-tracing-booster
+    ref: redhat
+environment:
+  staging:
+    source:
+      git:
+        ref: v7.3.0-redhat
+  production:
+    source:
+      git:
+        ref: v7.3.0-redhat
+metadata:
+  app:
+    launcher:
+      runsOn:
+        - 'none'

--- a/fuse/redhat731/istio-distributed-tracing/booster.yaml
+++ b/fuse/redhat731/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,20 @@
+name: Red Hat Fuse - Istio - Distributed Tracing
+description: Runs a Apache Camel application that utilizes Tracing on Istio
+source:
+  git:
+    url: https://github.com/jboss-fuse/fuse-istio-distributed-tracing-booster
+    ref: redhat
+environment:
+  staging:
+    source:
+      git:
+        ref: v7.3.1-redhat
+  production:
+    source:
+      git:
+        ref: v7.3.1-redhat
+metadata:
+  app:
+    launcher:
+      runsOn:
+        - 'none'

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -47,6 +47,13 @@ missions:
     SSO which adds security to your applications while centralizing the security configuration
   metadata:
     level: advanced
+- id: istio-distributed-tracing
+  name: Istio - Distributed Tracing
+  description: The Istio Distributed Tracing mission demonstrates how simple distributed
+    tracing can be integrated with an application running on an Istio-enabled cluster.
+  metadata:
+    level: expert
+    istio: true
 runtimes:
   - id: vert.x
     name: Eclipse Vert.x

--- a/nodejs/v10-community/istio-distributed-tracing/booster.yaml
+++ b/nodejs/v10-community/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,20 @@
+name: Node.js - Istio - Distributed Tracing
+description: Runs a Node.js application that utilizes Tracing on Istio
+source:
+  git:
+    url: https://github.com/nodeshift-starters/nodejs-istio-tracing
+    ref: master
+environment:
+  staging:
+    source:
+      git:
+        ref: v2.2.1
+  production:
+    source:
+      git:
+        ref: v2.2.1
+metadata:
+  app:
+    launcher:
+      runsOn:
+        - 'none'

--- a/nodejs/v10-redhat/istio-distributed-tracing/booster.yaml
+++ b/nodejs/v10-redhat/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,20 @@
+name: Node.js - Istio - Distributed Tracing
+description: Runs a Node.js application that utilizes Tracing on Istio
+source:
+  git:
+    url: https://github.com/nodeshift-starters/nodejs-istio-tracing-redhat
+    ref: master
+environment:
+  staging:
+    source:
+      git:
+        ref: v2.1.1
+  production:
+    source:
+      git:
+        ref: v2.1.1
+metadata:
+  app:
+    launcher:
+      runsOn:
+        - 'none'

--- a/nodejs/v12-community/istio-distributed-tracing/booster.yaml
+++ b/nodejs/v12-community/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,20 @@
+name: Node.js - Istio - Distributed Tracing
+description: Runs a Node.js application that utilizes Tracing on Istio
+source:
+  git:
+    url: https://github.com/nodeshift-starters/nodejs-istio-tracing
+    ref: master
+environment:
+  staging:
+    source:
+      git:
+        ref: v3.0.0
+  production:
+    source:
+      git:
+        ref: v3.0.0
+metadata:
+  app:
+    launcher:
+      runsOn:
+        - 'none'

--- a/nodejs/v8-community/istio-distributed-tracing/booster.yaml
+++ b/nodejs/v8-community/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,20 @@
+name: Node.js - Istio - Distributed Tracing
+description: Runs a Node.js application that utilizes Tracing on Istio
+source:
+  git:
+    url: https://github.com/nodeshift-starters/nodejs-istio-tracing
+    ref: master
+environment:
+  staging:
+    source:
+      git:
+        ref: v1.2.1
+  production:
+    source:
+      git:
+        ref: v1.2.1
+metadata:
+  app:
+    launcher:
+      runsOn:
+        - 'none'

--- a/nodejs/v8-redhat/istio-distributed-tracing/booster.yaml
+++ b/nodejs/v8-redhat/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,20 @@
+name: Node.js - Istio - Distributed Tracing
+description: Runs a Node.js application that utilizes Tracing on Istio
+source:
+  git:
+    url: https://github.com/nodeshift-starters/nodejs-istio-tracing-redhat
+    ref: master
+environment:
+  staging:
+    source:
+      git:
+        ref: v1.1.1
+  production:
+    source:
+      git:
+        ref: v1.1.1
+metadata:
+  app:
+    launcher:
+      runsOn:
+        - 'none'

--- a/spring-boot/current-community/istio-distributed-tracing/booster.yaml
+++ b/spring-boot/current-community/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,12 @@
+metadata:
+  app:
+    launcher:
+      runsOn:
+      - none
+name: Istio - Spring Boot - Distributed Tracing
+description: Booster to demonstrate how Istio's service mesh and Distributed Tracing
+  - Jaeger interact.
+source:
+  git:
+    url: https://github.com/snowdrop/spring-boot-istio-distributed-tracing-booster.git
+    ref: 2.1.3-2

--- a/spring-boot/current-redhat/istio-distributed-tracing/booster.yaml
+++ b/spring-boot/current-redhat/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,12 @@
+metadata:
+  app:
+    launcher:
+      runsOn:
+      - none
+name: Istio - Spring Boot - Distributed Tracing
+description: Booster to demonstrate how Istio's service mesh and Distributed Tracing
+  - Jaeger interact.
+source:
+  git:
+    url: https://github.com/snowdrop/spring-boot-istio-distributed-tracing-booster.git
+    ref: 2.1.3-2-redhat

--- a/spring-boot/previous-community/istio-distributed-tracing/booster.yaml
+++ b/spring-boot/previous-community/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,12 @@
+metadata:
+  app:
+    launcher:
+      runsOn:
+      - none
+name: Istio - Spring Boot - Distributed Tracing
+description: Booster to demonstrate how Istio's service mesh and Distributed Tracing
+  - Jaeger interact.
+source:
+  git:
+    url: https://github.com/snowdrop/spring-boot-istio-distributed-tracing-booster.git
+    ref: 1.5.19-4

--- a/spring-boot/previous-redhat/istio-distributed-tracing/booster.yaml
+++ b/spring-boot/previous-redhat/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,12 @@
+metadata:
+  app:
+    launcher:
+      runsOn:
+      - none
+name: Istio - Spring Boot - Distributed Tracing
+description: Booster to demonstrate how Istio's service mesh and Distributed Tracing
+  - Jaeger interact.
+source:
+  git:
+    url: https://github.com/snowdrop/spring-boot-istio-distributed-tracing-booster.git
+    ref: 1.5.19-4-redhat

--- a/thorntail/community/istio-distributed-tracing/booster.yaml
+++ b/thorntail/community/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,11 @@
+name: Thorntail - Istio - Distributed Tracing
+description: Runs a Thorntail application that utilizes Tracing with Jaeger on Istio
+source:
+  git:
+    url: https://github.com/thorntail-examples/istio-tracing
+    ref: '5'
+metadata:
+  app:
+    launcher:
+      runsOn:
+        - 'none'

--- a/thorntail/redhat/istio-distributed-tracing/booster.yaml
+++ b/thorntail/redhat/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,11 @@
+name: Thorntail - Istio - Distributed Tracing
+description: Runs a Thorntail application that utilizes Tracing with Jaeger on Istio
+source:
+  git:
+    url: https://github.com/thorntail-examples/istio-tracing-redhat
+    ref: '2.4.0-redhat-1'
+metadata:
+  app:
+    launcher:
+      runsOn:
+        - 'none'

--- a/vert.x/community/istio-distributed-tracing/booster.yaml
+++ b/vert.x/community/istio-distributed-tracing/booster.yaml
@@ -1,0 +1,20 @@
+name: Eclipse Vert.x - Istio - Distributed Tracing
+description: Runs a Eclipse Vert.x application that utilizes Tracing on Istio
+source:
+  git:
+    url: https://github.com/openshiftio-vertx-boosters/vertx-istio-distributed-tracing-booster
+    ref: master
+environment:
+  staging:
+    source:
+      git:
+        ref: v3
+  production:
+    source:
+      git:
+        ref: v3
+metadata:
+  app:
+    launcher:
+      runsOn:
+        - 'none'


### PR DESCRIPTION
ISTIO - Distributed tracing was removed in the previous commit. This one puts it back